### PR TITLE
Improve logging and handling messages with missing timestamp

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ exports.init = function  (ssb, config) {
 
   links.init(function (err, since) {
     pull(
-      ssb.createLogStream({gt: since || 0, live: true, limit: -1}),
+      ssb.createLogStream({gt: since || 0, live: true, sync: false}),
       pull.through(function () {
         process.stdout.write('x')
       }),

--- a/index.js
+++ b/index.js
@@ -62,7 +62,6 @@ exports.init = function  (ssb, config) {
         try { opts = {query: JSON.parse(opts) } } catch (err) {
         return pull.error(err)
       }
-    console.log('query', JSON.stringify(opts.query, null, 2))
       return links.read(opts, function (ts, cb) {
         ssb.sublevel('log').get(ts, function (err, key) {
           if(err) return cb(explain(err, 'missing timestamp:'+ts))


### PR DESCRIPTION
This prevents the following error:

```
Error: could not find matching timestamp for index:{"sync":true}
    at /home/cel/src/streamview-links/index.js:163:31
    at /home/cel/src/ssb-query/index.js:68:26
  Error: missing timestamp:undefined
    at /home/cel/src/ssb-query/index.js:68:29
    at /home/cel/src/scuttlebot/node_modules/secure-scuttlebutt/node_modules/level-sublevel/shell.js:101:15
  NotFoundError: Key not found in database
    at /home/cel/src/scuttlebot/node_modules/secure-scuttlebutt/node_modules/level-sublevel/shell.js:101:18
    at /home/cel/src/scuttlebot/node_modules/secure-scuttlebutt/node_modules/level-sublevel/nut.js:120:19
```

I also removed the query logging which produces a lot of console output
