### PR TITLE
add indexes for ordering by published time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A scuttlebot plugin which implements a [flumeview-query](https://github.com/flumedb/flumeview-query) index for the scuttlebutt context. 
 See flumeview-query's documentation for more info on how this works
 
+See [index.js](./index.js) for the current list of indexes offered by ssb-query.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var pull = require('pull-stream')
 var path = require('path')
 var FlumeQuery = require('flumeview-query')
@@ -21,12 +20,16 @@ exports.manifest = {
 //query mentions (backlinks & mentions)
 //query votes
 
+
+var INDEX_VERSION = 7
 var indexes = [
   {key: 'log', value: ['timestamp']},
   {key: 'clk', value: [['value', 'author'], ['value', 'sequence']] },
   {key: 'typ', value: [['value', 'content', 'type'], ['timestamp']] },
+  {key: 'tya', value: [['value', 'content', 'type'], ['value', 'timestamp']] },
   {key: 'cha', value: [['value', 'content', 'channel'], ['timestamp']] },
-  {key: 'aty', value: [['value', 'author'], ['value', 'content', 'type'], ['timestamp']]}
+  {key: 'aty', value: [['value', 'author'], ['value', 'content', 'type'], ['timestamp']]},
+  {key: 'ata', value: [['value', 'author'], ['value', 'content', 'type'], ['value', 'timestamp']]},
 ]
 
 //createHistoryStream( id, seq )
@@ -37,7 +40,7 @@ var indexes = [
 //[{$filter: {content: {type: <type>}}}, {$map: true}]
 
 exports.init = function  (ssb, config) {
-  var s = ssb._flumeUse('query', FlumeQuery(6, {indexes:indexes}))
+  var s = ssb._flumeUse('query', FlumeQuery(INDEX_VERSION, {indexes: indexes}))
   var read = s.read
   var explain = s.explain
   s.explain = function (opts) {
@@ -46,9 +49,10 @@ exports.init = function  (ssb, config) {
       opts = {query: JSON.parse(opts)}
     else if(isString(opts.query))
       opts.query = JSON.parse(opts.query)
+    debugger
     return explain(opts)
-
   }
+
   s.read = function (opts) {
     if(!opts) opts = {}
     if(isString(opts))


### PR DESCRIPTION
**Semver Δ**: `minor`

**Problem**: on index pages of many apps (Ticktack, Patchbay gatherings) I need messages ordered by published time. This is particularly important for initial sync / identity restore, where messages are received from people in all sorts of order and can lead to a surprisingly disorienting view of what's going on

**Solution** : adds two indexes which add ability to `$filter` on `msg.value.timestamp` (asserted publish time). This PR puts these new indices below existing indices so that partial matches will behaviour is preserved (e.g. a filter on `type` and `author` will default to the existing `aty`index not to the new `ata` index) 