### PR TITLE
feedback on additional indexes needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ var indexes = [
   {key: 'cha', value: [['value', 'content', 'channel'], ['timestamp']] },
   {key: 'aty', value: [['value', 'author'], ['value', 'content', 'type'], ['timestamp']]},
   {key: 'ata', value: [['value', 'author'], ['value', 'content', 'type'], ['value', 'timestamp']]},
-  {key: 'art', value: [['value', 'content', 'root'], ['value', 'timestamp']]}
+  {key: 'art', value: [['value', 'content', 'root'], ['value', 'timestamp']]},
+  {key: 'lor', value: [['value', 'timestamp' ]]}
 ]
 
 //createHistoryStream( id, seq )

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ exports.manifest = {
 //query votes
 
 
-var INDEX_VERSION = 7
+var INDEX_VERSION = 8
 var indexes = [
   {key: 'log', value: ['timestamp']},
   {key: 'clk', value: [['value', 'author'], ['value', 'sequence']] },
@@ -30,6 +30,7 @@ var indexes = [
   {key: 'cha', value: [['value', 'content', 'channel'], ['timestamp']] },
   {key: 'aty', value: [['value', 'author'], ['value', 'content', 'type'], ['timestamp']]},
   {key: 'ata', value: [['value', 'author'], ['value', 'content', 'type'], ['value', 'timestamp']]},
+  {key: 'art', value: [['value', 'content', 'root'], ['value', 'timestamp']]}
 ]
 
 //createHistoryStream( id, seq )


### PR DESCRIPTION
@mixmix's chronological index of posts had me thrilled, so I got excited and created yet another index that allows me to get chronological threads from a message root.

With this I was able to easily create threads within http://github.com/evbogue/mvd

`mvd` also serves a chronological posts feed using @mixmix's latest patch.

What I really want is an index of _everything_ in chronological order, but I couldn't figure out how to do that.

We don't need to merge this, however I want to have a discussion about which indexes would be the best indexes to have available via `ssb-query`.