### PR TITLE
further work on #6 - use rts instead of value.timestamp for asserted

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,13 @@ var indexes = [
   {key: 'aty', value: [['value', 'author'], ['value', 'content', 'type'], ['timestamp']]},
   {key: 'ata', value: [['value', 'author'], ['value', 'content', 'type'], ['value', 'timestamp']]},
   {key: 'art', value: [['value', 'content', 'root'], ['value', 'timestamp']]},
-  {key: 'lor', value: [['value', 'timestamp' ]]}
+  {key: 'lor', value: [['rts']]}
 ]
+
+function mapRts (msg) {
+  msg.rts = Math.min(msg.timestamp, msg.value.timestamp)
+  return msg
+}
 
 //createHistoryStream( id, seq )
 //[{$filter: {author: <id>, sequence: {$gt: <seq>}}}, {$map: true}]
@@ -42,7 +47,7 @@ var indexes = [
 //[{$filter: {content: {type: <type>}}}, {$map: true}]
 
 exports.init = function  (ssb, config) {
-  var s = ssb._flumeUse('query', FlumeQuery(INDEX_VERSION, {indexes: indexes}))
+  var s = ssb._flumeUse('query', FlumeQuery(INDEX_VERSION, {indexes: indexes, map: mapRts}))
   var read = s.read
   var explain = s.explain
   s.explain = function (opts) {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ var indexes = [
   {key: 'cha', value: [['value', 'content', 'channel'], ['timestamp']] },
   {key: 'aty', value: [['value', 'author'], ['value', 'content', 'type'], ['timestamp']]},
   {key: 'ata', value: [['value', 'author'], ['value', 'content', 'type'], ['value', 'timestamp']]},
-  {key: 'art', value: [['value', 'content', 'root'], ['value', 'timestamp']]}
+  {key: 'art', value: [['value', 'content', 'root'], ['value', 'timestamp']]},
+  {key: 'lor', value: [['value', 'timestamp' ]]}
 ]
 
 //createHistoryStream( id, seq )

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ exports.manifest = {
 //query votes
 
 
-var INDEX_VERSION = 7
+var INDEX_VERSION = 8
 var indexes = [
   {key: 'log', value: ['timestamp']},
   {key: 'clk', value: [['value', 'author'], ['value', 'sequence']] },
@@ -30,6 +30,7 @@ var indexes = [
   {key: 'cha', value: [['value', 'content', 'channel'], ['timestamp']] },
   {key: 'aty', value: [['value', 'author'], ['value', 'content', 'type'], ['timestamp']]},
   {key: 'ata', value: [['value', 'author'], ['value', 'content', 'type'], ['value', 'timestamp']]},
+  {key: 'art', value: [['value', 'content', 'root'], ['value', 'timestamp']]}
 ]
 
 //createHistoryStream( id, seq )

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "explain-error": "^1.0.1",
-    "flumeview-query": "^6.0.0",
+    "flumeview-query": "github:mmckegg/flumeview-query#map",
     "pull-stream": "^3.6.2"
   },
   "devDependencies": {},


### PR DESCRIPTION
**This PR continues from #6 but modifies use of `['value', 'timestamp']` indexes to use `['rts']` which I've added as a computed property that is `Math.min(msg.timestamp, msg.value.timestamp)`.**

This prevents unwanted pinning of messages when the author posts a message with a timestamp in the distant future (this message currently would get stuck at the top of your feed). 

As with #6, this doesn't necessarily need to be merged. It's more about a discussion. However, we do need to come to some good consensus about this if we want to avoid all of the duplicate indexes that plague clients at the moment!

I would like to avoid having to do custom indexes for PATCHTRON entirely. So far I've managed to do almost everything just using `ssb-backlinks`, but to do the public feed rollup, I need the entire log but in a safe asserted order. 

Maybe this should be a PR for `createFeedStream` instead?

(this depends on https://github.com/flumedb/flumeview-query/pull/14 being merged to allow custom computed query props)