### PR TITLE
if claimed timestamp is zero, use received time instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var indexes = [
 ]
 
 function mapRts (msg) {
-  msg.rts = Math.min(msg.timestamp, msg.value.timestamp)
+  msg.rts = Math.min(msg.timestamp, msg.value.timestamp) || msg.timestamp
   return msg
 }
 
@@ -69,5 +69,9 @@ exports.init = function  (ssb, config) {
   }
   return s
 }
+
+
+
+
 
 


### PR DESCRIPTION
this gives the option to disable timestamps, while causing minimal disruption to applications: if you set your timestamp as zero, the application just uses the received time.

as suggested: https://github.com/ssbc/ssb-query/commit/09855096779fb92de66260cbad882716151554e1#r30683929