### PR TITLE
Fix extra square bracket in example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -20,7 +20,7 @@ most recently published channels, with timestamp and message count.
       "count": {"$count": true},
       "timestamp": {"$max": ["value", "timestamp"]}
   }},
-  {"$sort": [["timestamp"], ["count"]]}]
+  {"$sort": [["timestamp"], ["count"]]}
 ]
 
 ```


### PR DESCRIPTION
Just tried running this query and found it had an extra square bracket.